### PR TITLE
remove threading to fix race conditions

### DIFF
--- a/src/ReduceGeometry.jl
+++ b/src/ReduceGeometry.jl
@@ -168,7 +168,7 @@ function pairNumbersDict(siteList::AbstractVector{R}, PairList::AbstractVector{R
 
     pairNumberVec = Vector{Pair{Tuple{R,R},Int}}(undef, length(pairs))
 
-    Threads.@threads for i in eachindex(pairNumberVec, pairs)
+    for i in eachindex(pairNumberVec, pairs)
         R1, R2 = pairs[i]
         pairNumberVec[i] = (R1, R2) => pairNumber(R1, R2, MapToPairDict, nonRefSyms, refSyms, Basis)
     end
@@ -220,7 +220,7 @@ function CalcSiteSum(PairList::AbstractVector{<:Rv}, PairTypes, siteList::Abstra
 
     pairs = fill(sumElements(0, 0, 0, 0), Nsum, Npairs) # generate empty matrix
 
-    Threads.@threads for j in eachindex(PairList) #lhs of flow eqs
+    for j in eachindex(PairList) #lhs of flow eqs
         Rj = PairList[j]
         Ri = Basis.refSites[PairTypes[j].xi]  # current reference site
         for (k, Rk) in enumerate(siteList)
@@ -247,7 +247,7 @@ function reduceSiteSum(siteSum)
     Nsum, Npairs = size(siteSum)
     reducedSum = fill(sumElements(0, 0, 0, 0), Nsum + 1, Npairs) #add +1 to Nsum to always have a (0,0,0,0) sumElements so we can always cut off last index!
     MaxNsum = 1
-    Threads.@threads for j in 1:Npairs
+    for j in 1:Npairs
         jSumList = sort(@view siteSum[:, j])
         uniqueElements = unique(jSumList, dims=1)
         len = length(uniqueElements)


### PR DESCRIPTION
This is not exactly a fix: if you use threading on SpinFRGLattices I guess there's a reason. But I managed to fix the data race mentioned here (https://github.com/NilsNiggemann/PMFRG.jl/issues/37), apparently... More details here: #3 